### PR TITLE
Change the assembly target platform from x86 to AnyCPU for Visual Studio 2022 compatibility

### DIFF
--- a/source/Platforms/Win32/v60/Daffodil.CPPTasks.Win32.v60/Daffodil.CPPTasks.Win32.v60.csproj
+++ b/source/Platforms/Win32/v60/Daffodil.CPPTasks.Win32.v60/Daffodil.CPPTasks.Win32.v60.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/source/Platforms/Win32/v70/Daffodil.CPPTasks.Win32.v70/Daffodil.CPPTasks.Win32.v70.csproj
+++ b/source/Platforms/Win32/v70/Daffodil.CPPTasks.Win32.v70/Daffodil.CPPTasks.Win32.v70.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/source/Platforms/Win32/v71/Daffodil.CPPTasks.Win32.v71/Daffodil.CPPTasks.Win32.v71.csproj
+++ b/source/Platforms/Win32/v71/Daffodil.CPPTasks.Win32.v71/Daffodil.CPPTasks.Win32.v71.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/source/Platforms/Win32/v80/Daffodil.CPPTasks.Win32.v80/Daffodil.CPPTasks.Win32.v80.csproj
+++ b/source/Platforms/Win32/v80/Daffodil.CPPTasks.Win32.v80/Daffodil.CPPTasks.Win32.v80.csproj
@@ -23,7 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,7 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Visual Studio 2022 is based on the x64 platform. Consequently, MSBuild is executed as a 64-bit process and therefore cannot load assemblies that were only compiled for 32-bit platform. This commit sets the target platform to AnyCPU so that the assemblies can be loaded in a 32-bit environment (VS2010 to VS2019) as well as in a 64-bit environment (VS2022).